### PR TITLE
58 io manager

### DIFF
--- a/Dockerfile_app.REPLACE
+++ b/Dockerfile_app.REPLACE
@@ -47,6 +47,7 @@ RUN pip3 install \
     dagster_snowflake==0.17.7 \
     dagster_dbt==0.17.7 \
     dagster_pandas==0.17.7 \
+    dagster_aws==0.17.7 \
     dagster_hex \
     dbt-core==1.3.1 \
     dbt-snowflake==1.3.0 \

--- a/discursus_data_platform/assets/sources/gdelt_source_assets.py
+++ b/discursus_data_platform/assets/sources/gdelt_source_assets.py
@@ -1,7 +1,9 @@
 from dagster import asset, AssetIn, Output, FreshnessPolicy
+from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 import pandas as pd
 import boto3
 from io import StringIO
+
 import resources.my_resources
 from resources.ml_enrichment_tracker import MLEnrichmentJobTracker
 

--- a/discursus_data_platform/repository.py
+++ b/discursus_data_platform/repository.py
@@ -1,11 +1,11 @@
 from dagster import (
-    repository, 
     AssetSelection, 
     build_asset_reconciliation_sensor,
-    load_assets_from_package_module,
-    with_resources,
-    file_relative_path
+    file_relative_path,
+    repository, 
+    with_resources
 )
+from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 from dagster_dbt import dbt_cli_resource, load_assets_from_dbt_project
 
 from assets.sources import gdelt_source_assets, airbyte_source_assets
@@ -16,41 +16,45 @@ from assets.data_apps import public_dashboard_assets, social_media_assets
 DBT_PROFILES_DIR = file_relative_path(__file__, "./dw")
 DBT_PROJECT_DIR = file_relative_path(__file__, "./dw")
 
-protest_wh_assets = with_resources(
+protest_assets = with_resources(
     load_assets_from_dbt_project(
         project_dir = DBT_PROJECT_DIR, 
         profiles_dir = DBT_PROFILES_DIR, 
         key_prefix = ["data_warehouse"],
         use_build_command = True
-    ),
-    {
+    ) + [
+        gdelt_source_assets.gdelt_events,
+        gdelt_source_assets.gdelt_mentions,
+        airbyte_source_assets.protest_groupings,
+        gdelt_enriched_assets.gdelt_mentions_enhanced,
+        gdelt_enriched_assets.gdelt_ml_enriched_mentions,
+        public_dashboard_assets.hex_main_dashboard_refresh,
+        social_media_assets.hex_daily_assets_refresh,
+        social_media_assets.twitter_share_daily_assets
+    ],
+    resource_defs = {
         "dbt": dbt_cli_resource.configured(
             {
                 "project_dir": DBT_PROFILES_DIR,
                 "profiles_dir": DBT_PROJECT_DIR,
             },
         ),
+        "io_manager": s3_pickle_io_manager.configured(
+            {"s3_bucket": "discursus-io", "s3_prefix": "platform"}
+        ),
+        "s3": s3_resource,
     },
 )
 
-platform_assets = [
-    gdelt_source_assets.gdelt_events,
-    gdelt_source_assets.gdelt_mentions,
-    airbyte_source_assets.protest_groupings,
-    gdelt_enriched_assets.gdelt_mentions_enhanced,
-    gdelt_enriched_assets.gdelt_ml_enriched_mentions,
-    public_dashboard_assets.hex_main_dashboard_refresh,
-    social_media_assets.hex_daily_assets_refresh,
-    social_media_assets.twitter_share_daily_assets,
-
+asset_sensor = [
     build_asset_reconciliation_sensor(
         asset_selection=AssetSelection.all(),
         name="asset_reconciliation_sensor",
         minimum_interval_seconds = 60 * 5
-    )        
+    )
 ]
 
 
 @repository
 def discursus_repo():
-    return protest_wh_assets + platform_assets
+    return protest_assets + asset_sensor


### PR DESCRIPTION
# Description

Fixes #58 

# Type of change

Please select option that is relevant.

- [x] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Infrastructure (provides the necessary resources for platform to run)

# Checklist:

- [x] My pull request represents one story (logical piece of work).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran the data platform in my development environment without error.
- [x] I ran the data pipelines in my development environment without error.
- [x] I updated the README file with up-to-date asset lineage graphs, data wareohouse DAG and ERD

## To produce README graphs
Asset lineage graphs
- Run the data platform locally
- Click on Assets in the top-right menu
- Click on View global asset lineage
- Screen capture the lineage
- Save to `./resources/images/asset_lineage_graph.png`

Data warehouse ERD
- `cd ./semantics`
- `droughty dbml --profile-dir ./droughty_profiles.yml --project-dir ./droughty_projects.yml`
- `dbdocs build dbml/discursus_analytics.dbml`
- Go to link provided as output to previous command
- Click on Relationships in top menu
- Click on Download util and export to png
- Save to `./resources/images/dw_erd.png`

Data Warehouse DAG
- `cd ./discursus_data_platform/dw/`
- `dbt docs generate --profiles-dir ./`
- `dbt docs serve --profiles-dir ./`
- Once on the local dbt documentations website, click on the View Lineage Graph icon at bottom right
- Unselect the `analysis` resources
- Screen capture the DAG
- Save to `./resources/images/dw_dag.png`